### PR TITLE
Set the es/ build to be the `main`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node/",
     "umd/"
   ],
-  "main": "src/index.js",
+  "main": "es/index.js",
   "module": "es/index.js",
   "esnext": "esnext/index.js",
   "scripts": {


### PR DESCRIPTION
Otherwise we have to include `src/` in the npm package, which we
probably don't want to do ?